### PR TITLE
Unset sender_string if not used

### DIFF
--- a/lib/Client/Client.php
+++ b/lib/Client/Client.php
@@ -177,6 +177,14 @@ class Client
             'charset' => urlencode($this->config['charset']),
         ];
 
+        //
+        // if sender_string is passed and is empty, it's impossible to use sender_number as sender,
+        // Skebby will use the default sender set in Skebby Administration Panel
+        //
+        if (trim($request['sender_string']) == '') {
+            unset($request['sender_string']);
+        }
+
         $serializedRequest = [];
         foreach ($request as $key => $value) {
             $serializedRequest[] = "$key=$value";

--- a/lib/Client/Client.php
+++ b/lib/Client/Client.php
@@ -177,11 +177,11 @@ class Client
             'charset' => urlencode($this->config['charset']),
         ];
 
-        //
-        // if sender_string is passed and is empty, it's impossible to use sender_number as sender,
-        // Skebby will use the default sender set in Skebby Administration Panel
-        //
-        if (trim($request['sender_string']) == '') {
+        /*
+        * if sender_string is passed and is empty, it's impossible to use sender_number as sender,
+        * Skebby will use the default sender set in Skebby Administration Panel
+        */
+        if (trim($request['sender_string']) === '') {
             unset($request['sender_string']);
         }
 

--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -195,7 +195,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             'password=test&'.
             'method=send_sms_classic&'.
             'sender_number=393333333333&'.
-            'sender_string=&'.
             'recipients=[{"recipient":"393930000123","name":"Mario"}]&'.
             'text=Hi+${name}&'.
             'user_reference=WelcomeMario&'.


### PR DESCRIPTION
If `sender_string` is empty, Skebby ignore the `sender_number` and uses the Default sender set in the Administration Panel